### PR TITLE
presets: add markdown to tag matching

### DIFF
--- a/lua/pears/presets/tag_matching.lua
+++ b/lua/pears/presets/tag_matching.lua
@@ -13,7 +13,8 @@ return function(conf, opts)
         "jsx",
         "tsx",
         "html",
-        "xml"}},
+        "xml",
+        "markdown"}},
     capture_content = "^[a-zA-Z_\\-]+",
     expand_when = "[>]",
     should_expand = function(args)


### PR DESCRIPTION
Can we add `markdown` to the tag matching file types? A lot of static site generators use markdown and it is allowed to put arbitrary HTML tags  everywhere.