### PR TITLE
Fix `tag_matching` example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ For an example, take a look at the `tag_matching` preset.
 You can also enable this using the preset.
 
 ```lua
-require "pears".setup(function(conf
+require "pears".setup(function(conf)
   conf.preset "tag_matching"
 end)
 ```


### PR DESCRIPTION
added a missing closing parenthesis (oh the irony 😛)