### PR TITLE
Presets: add eruby to tag matching filetypes

### DIFF
--- a/lua/pears/presets/tag_matching.lua
+++ b/lua/pears/presets/tag_matching.lua
@@ -15,7 +15,8 @@ return function(conf, opts)
         "tsx",
         "html",
         "xml",
-        "markdown"}},
+        "markdown",
+        "eruby"}},
     capture_content = "^[a-zA-Z_\\-]+",
     expand_when = R.char "[>]",
     should_expand = R.all_of(


### PR DESCRIPTION
eRuby https://en.wikipedia.org/wiki/ERuby) is the default HTML template language for Ruby on Rails. Tag matching is applicable to this filetype.