### PR TITLE
Correctly close tags that contain digits

### DIFF
--- a/lua/pears/presets/tag_matching.lua
+++ b/lua/pears/presets/tag_matching.lua
@@ -16,7 +16,7 @@ return function(conf, opts)
         "html",
         "xml",
         "markdown"}},
-    capture_content = "^[a-zA-Z_\\-]+",
+    capture_content = "^[a-zA-Z0-9_\\-]+",
     expand_when = R.char "[>]",
     should_expand = R.all_of(
       -- Don't expand for self closing tags <input type="text" />

--- a/lua/pears/presets/tag_matching.lua
+++ b/lua/pears/presets/tag_matching.lua
@@ -15,7 +15,8 @@ return function(conf, opts)
         "tsx",
         "html",
         "xml",
-        "markdown"}},
+        "markdown",
+        "eruby"}},
     capture_content = "^[a-zA-Z0-9_\\-]+",
     expand_when = R.char "[>]",
     should_expand = R.all_of(

--- a/lua/pears/rule.lua
+++ b/lua/pears/rule.lua
@@ -194,7 +194,7 @@ function Rule.child_of_node(pattern_or_list, deep)
             if Utils.match(current:type(), pattern_or_list) then
               return true
             end
-            current = current.parent
+            current = current:parent()
           end
         else
           return Utils.match(node:type(), pattern_or_list)


### PR DESCRIPTION
Tags such as `<h1>` where not being closed correctly, anything from the digit onwards was being truncated:

```
<h1> --> <h1></h>
```

This issue should now be fixed.