### PR TITLE
Correctly close tags that contain digits

### DIFF
--- a/lua/pears/presets/tag_matching.lua
+++ b/lua/pears/presets/tag_matching.lua
@@ -17,7 +17,7 @@ return function(conf, opts)
         "xml",
         "markdown",
         "eruby"}},
-    capture_content = "^[a-zA-Z_\\-]+",
+    capture_content = "^[a-zA-Z0-9_\\-]+",
     expand_when = R.char "[>]",
     should_expand = R.all_of(
       -- Don't expand for self closing tags <input type="text" />


### PR DESCRIPTION
Tags such as `<h1>` were not being closed correctly, anything from the
digit onwards was being truncated:

```
<h1> --> <h1></h>
```

This issue should now be fixed.