### PR TITLE
Add virtual_key rule

### DIFF
--- a/lua/pears.lua
+++ b/lua/pears.lua
@@ -172,8 +172,15 @@ function M._handle_return(bufnr)
         direction = Pointer.Direction.Forward
       }
 
-      if (after and after.leaf and after.leaf.key == before.leaf.key) or
-        (not after and input:expand(nil, true)) then
+      local pair_closed = (after and after.leaf and after.leaf.key == before.leaf.key)
+
+      -- If there isn't a closing pair, try to expand to handle the case
+      -- where the pair has been configured to expand on enter.
+      if not pair_closed then
+        pair_closed = input:expand(nil, Input.VirtualKey.ENTER)
+      end
+
+      if pair_closed then
         if R.pass(before.leaf.should_return {
           leaf = before.leaf,
           input = input,

--- a/lua/pears.lua
+++ b/lua/pears.lua
@@ -172,7 +172,8 @@ function M._handle_return(bufnr)
         direction = Pointer.Direction.Forward
       }
 
-      if after and after.leaf and after.leaf.key == before.leaf.key then
+      if (after and after.leaf and after.leaf.key == before.leaf.key) or
+        (not after and input:expand(nil, true)) then
         if R.pass(before.leaf.should_return {
           leaf = before.leaf,
           input = input,

--- a/lua/pears/input.lua
+++ b/lua/pears/input.lua
@@ -10,6 +10,8 @@ local api = vim.api
 
 local Input = {}
 
+Input.VirtualKey = R.VirtualKey
+
 function Input.new(bufnr, pear_tree, opts)
   opts = opts or {}
 
@@ -56,11 +58,12 @@ function Input:_destroy_context(context)
   context:destroy()
 end
 
-function Input:expand(char, enter_pressed)
+function Input:expand(char, virtual_key)
+  virtual_key = virtual_key or self.VirtualKey.NONE
   local pending = self.pending_stack[1]
 
   if pending then
-    local did_expand = self:_expand_context(pending, char, enter_pressed)
+    local did_expand = self:_expand_context(pending, char, virtual_key)
 
     if did_expand then
       return true, pending
@@ -182,7 +185,7 @@ function Input:_handle_expansion(args)
   end
 end
 
-function Input:_make_event_args(char, context, leaf, enter_pressed)
+function Input:_make_event_args(char, context, leaf, virtual_key)
   return {
     char = char,
     context = context,
@@ -191,18 +194,18 @@ function Input:_make_event_args(char, context, leaf, enter_pressed)
     cursor = Utils.get_cursor(),
     bufnr = self.bufnr,
     input = self,
-    enter_pressed = enter_pressed,
+    virtual_key = virtual_key,
   }
 end
 
-function Input:_expand_context(context, char, enter_pressed)
+function Input:_expand_context(context, char, virtual_key)
   local leaf = context.leaf
 
   if not leaf then return false end
 
-  local event = self:_make_event_args(char, context, leaf, enter_pressed)
+  local event = self:_make_event_args(char, context, leaf, virtual_key)
 
-  if not char or R.pass(leaf.expand_when(event)) then
+  if (not char and not virtual_key) or R.pass(leaf.expand_when(event)) then
     local expanded = false
 
     if R.pass(leaf.should_expand(event)) then

--- a/lua/pears/input.lua
+++ b/lua/pears/input.lua
@@ -56,11 +56,11 @@ function Input:_destroy_context(context)
   context:destroy()
 end
 
-function Input:expand(char)
+function Input:expand(char, enter_pressed)
   local pending = self.pending_stack[1]
 
   if pending then
-    local did_expand = self:_expand_context(pending, char)
+    local did_expand = self:_expand_context(pending, char, enter_pressed)
 
     if did_expand then
       return true, pending
@@ -182,7 +182,7 @@ function Input:_handle_expansion(args)
   end
 end
 
-function Input:_make_event_args(char, context, leaf)
+function Input:_make_event_args(char, context, leaf, enter_pressed)
   return {
     char = char,
     context = context,
@@ -190,16 +190,17 @@ function Input:_make_event_args(char, context, leaf)
     lang = self.lang,
     cursor = Utils.get_cursor(),
     bufnr = self.bufnr,
-    input = self
+    input = self,
+    enter_pressed = enter_pressed,
   }
 end
 
-function Input:_expand_context(context, char)
+function Input:_expand_context(context, char, enter_pressed)
   local leaf = context.leaf
 
   if not leaf then return false end
 
-  local event = self:_make_event_args(char, context, leaf)
+  local event = self:_make_event_args(char, context, leaf, enter_pressed)
 
   if not char or R.pass(leaf.expand_when(event)) then
     local expanded = false

--- a/lua/pears/rule.lua
+++ b/lua/pears/rule.lua
@@ -2,6 +2,11 @@ local Utils = require "pears.utils"
 
 local Rule = {}
 
+Rule.VirtualKey = {
+  ENTER = "enter",
+  NONE = "__NONE__"
+}
+
 Rule.SKIP = "__SKIP__"
 
 local function pattern_to_list(pattern, at_start, args)
@@ -205,9 +210,9 @@ function Rule.child_of_node(pattern_or_list, deep)
     end)
 end
 
-function Rule.enter_pressed()
+function Rule.virtual_key(virtual_key)
   return function(args)
-    return args.enter_pressed
+    return args.virtual_key == virtual_key
   end
 end
 

--- a/lua/pears/rule.lua
+++ b/lua/pears/rule.lua
@@ -205,6 +205,12 @@ function Rule.child_of_node(pattern_or_list, deep)
     end)
 end
 
+function Rule.enter_pressed()
+  return function(args)
+    return args.enter_pressed
+  end
+end
+
 function Rule.pass(result)
   return result == Rule.SKIP or result
 end


### PR DESCRIPTION
Closes #18

Allows pairs to be configured to only insert the closing pair after enter is pressed.

A new rule is added called `enter_pressed`. It can be used with `expand_when`
to only expand when enter is pressed. 

Here is an example:
```lua
  conf.pair('{', {
    close = '}',
    expand_when = R.enter_pressed()
  })
```