### PR TITLE
Fix for Rule.all_of

### DIFF
--- a/lua/pears/rule.lua
+++ b/lua/pears/rule.lua
@@ -85,8 +85,8 @@ function Rule.all_of(...)
   local rules = {...}
 
   return function(args)
-    for i, rule in ipairs(rules) do
-      if rule(args) == false then
+    for _, rule in ipairs(rules) do
+      if not rule(args) then
         return false
       end
     end


### PR DESCRIPTION
When using `child_of_node` inside of `all_of`, if the pattern doesn't
match it returns `nil`. The problem is it was comparing this to `false`,
which made it act as if there was a match. Use `not` instead.