### PR TITLE
feat: include svelte and vue to tag_matching preset

### DIFF
--- a/lua/pears/presets/tag_matching.lua
+++ b/lua/pears/presets/tag_matching.lua
@@ -17,6 +17,8 @@ return function(conf, opts)
         "php",
         "jsx",
         "tsx",
+        "svelte",
+        "vue",
         "html",
         "xml",
         "markdown",


### PR DESCRIPTION
I think it makes sense to include Svelte and Vue for the `tag_matching` preset.