### PR TITLE
Add ability disable a buffer with a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ interface PearsConfig {
 
   // A list of filetypes to never attach it to, basically not including this plugin at all.
   disabled_filetypes(filetypes: string[]): void;
+
+  // A function to determine whether to disable attaching to the given buffer.
+  // If the function returns `true` this plugin will be disabled for that buffer.
+  disable(func: (bufnr: number) => boolean): void;
 }
 
 interface PearsPairConfig {

--- a/lua/pears.lua
+++ b/lua/pears.lua
@@ -35,6 +35,10 @@ end
 function M.attach(bufnr)
   bufnr = bufnr or api.nvim_get_current_buf()
 
+  if Utils.is_func(M.config.disable) and M.config.disable(bufnr) then
+    return
+  end
+
   -- Global filetype disabled list
   if Utils.is_table(M.config.disabled_filetypes)
     and vim.tbl_contains(


### PR DESCRIPTION
This PR adds the ability to have more precise control over when to disable this plugin for a given buffer. Currently there is a `disabled_filetypes` option, but sometimes you may want to disable based on other criteria.

In my case, opening large typescript files can cause a multi-second delay when using this plugin, or treesitter in general is enabled. `nvim-treesitter` lets you pass a function to disable things. I currently use this:
```lua
function M.disable(lang, bufnr)
  return vim.tbl_contains(disabled_filetypes, lang)
    or (lang == "typescript" and vim.api.nvim_buf_line_count(bufnr) > 10000)
end
``` 
With this PR, I can reuse this function to disable `pears.nvim` as well.
```lua
  conf.disable(function (bufnr)
    local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
    -- Use the same disabling logic I use for treesitter.
    return treesitter_config.disable(filetype, bufnr)
  end)
```

